### PR TITLE
Fix get headers code block issue

### DIFF
--- a/src/components/HeadersAccordion.tsx
+++ b/src/components/HeadersAccordion.tsx
@@ -33,9 +33,9 @@ export default function HeadersAccordion({ headers }: any) {
           </AccordionButton>
         </h2>
         <AccordionPanel>
-          {headers?.map((h: any, i: number) => {
+          {headers?.map((h: any, index: number) => {
             return (
-              <Link href={`#${h.text}`} key={i}>
+              <Link href={`#${h.text}`} key={index}>
                 <Box
                   p={1}
                   _hover={{

--- a/src/components/HeadersAccordion.tsx
+++ b/src/components/HeadersAccordion.tsx
@@ -33,9 +33,9 @@ export default function HeadersAccordion({ headers }: any) {
           </AccordionButton>
         </h2>
         <AccordionPanel>
-          {headers?.map((h: any) => {
+          {headers?.map((h: any, i: number) => {
             return (
-              <Link href={`#${h.text}`} key={h.text}>
+              <Link href={`#${h.text}`} key={i}>
                 <Box
                   p={1}
                   _hover={{

--- a/src/scripts/get-headings.ts
+++ b/src/scripts/get-headings.ts
@@ -1,8 +1,10 @@
 export default async function getHeadings(source: any) {
     // Get each line individually, and filter out anything that
-    // isn't a heading.
+    // isn't a heading. Ignore headings within code blocks.
+    let isInCodeBlock = false;
     const headingLines = source.split('\n').filter((line: any) => {
-        return line.match(/^###*\s/);
+        if (line.match(/^```/)) { isInCodeBlock = !isInCodeBlock };
+        return isInCodeBlock ? false : line.match(/^###*\s/);
     });
 
     // Transform the string '## Some text' into an object


### PR DESCRIPTION
Hi there! It looks like the issue I have a solution to on hasn't yet made it from the roadmap into Github. I believe I have a fix for the "get-headings gets md inside of code snippets" bug in the roadmap (and I also fixed an issue with the headers keys that could cause problems if two headers have the same name) - take a look and let me know what you think. I've verified that it's working locally but haven't written the tests yet.

I'm opening as a draft PR for now while I work on the unit test. 

