### PR TITLE
Add Step component to getHeadings function

### DIFF
--- a/src/components/Content/Step.tsx
+++ b/src/components/Content/Step.tsx
@@ -1,10 +1,14 @@
 import {
     Heading,
-    Box,
     Flex
 } from '@chakra-ui/react'
 
-const Step = ({ number, title }) => {
+type StepProps = {
+    number: number,
+    title: string,
+};
+
+const Step = ({ number, title }: StepProps) => {
 
     // for (let i = 0; i < title.length; i++) {
     //     if (title[i] == '`') {

--- a/src/components/WrittenBy.js
+++ b/src/components/WrittenBy.js
@@ -32,7 +32,7 @@ export default function WrittenBy({ frontMatter }) {
             <Avatar src={`/authors/${data.data.data.image}`} size="xl" mb={2} alt={`Image of ${frontMatter.author}`} />
             <Flex flexDir="column" align="center" px={4} textAlign="center">
                 {
-                    data.data.data.links.twitter ?
+                    data.data.data.links?.twitter ?
                         <Text>Written By <Link textDecor="underline" href={data.data.data.links.twitter} isExternal>{data.data.data.name}</Link></Text>
                         : <Text>Written By {data.data.data.name}</Text>
                 }

--- a/src/scripts/get-headings.ts
+++ b/src/scripts/get-headings.ts
@@ -2,16 +2,23 @@ export default async function getHeadings(source: any) {
     // Get each line individually, and filter out anything that
     // isn't a heading. Ignore headings within code blocks.
     let isInCodeBlock = false;
+    let stepComponentRegex = new RegExp(/^<Step[^>]+number[^>]+title[^>]+>|^<Step[^>]+title[^>]+number[^>]+>/);
     const headingLines = source.split('\n').filter((line: any) => {
         if (line.match(/^```/)) { isInCodeBlock = !isInCodeBlock };
-        return isInCodeBlock ? false : line.match(/^###*\s/);
+        return isInCodeBlock ? false : line.match(/^###*\s/) || line.match(stepComponentRegex);
     });
 
-    // Transform the string '## Some text' into an object
+    // Transform the string '## Some text' or '<Step ... />' into an object
     // with the shape '{ text: 'Some text', level: 2 }'
     const headingInfo = headingLines.map((raw: any) => {
         let level = 0;
         let copy = raw;
+
+        if (copy.includes("<Step")) {
+            const step = copy.replace(/(.+number=\\{0,1}")([^"]+)(\\{0,1}".+)/, "$2");
+            const title = copy.replace(/(.+title=\\{0,1}")([^"]+)(\\{0,1}".+)/, "$2");
+            return { text: `${step}. ${title}`, level: 2 };
+        } 
 
         while (copy[0] === '#') {
             level++;

--- a/src/scripts/get-headings.ts
+++ b/src/scripts/get-headings.ts
@@ -2,10 +2,9 @@ export default async function getHeadings(source: any) {
     // Get each line individually, and filter out anything that
     // isn't a heading. Ignore headings within code blocks.
     let isInCodeBlock = false;
-    let stepComponentRegex = new RegExp(/^<Step[^>]+number[^>]+title[^>]+>|^<Step[^>]+title[^>]+number[^>]+>/);
     const headingLines = source.split('\n').filter((line: any) => {
         if (line.match(/^```/)) { isInCodeBlock = !isInCodeBlock };
-        return isInCodeBlock ? false : line.match(/^###*\s/) || line.match(stepComponentRegex);
+        return isInCodeBlock ? false : line.match(/^###*\s/) || line.match(/^<Step[^>]+title[^>]+>/);
     });
 
     // Transform the string '## Some text' or '<Step ... />' into an object
@@ -15,9 +14,9 @@ export default async function getHeadings(source: any) {
         let copy = raw;
 
         if (copy.includes("<Step")) {
-            const step = copy.replace(/(.+number=\\{0,1}")([^"]+)(\\{0,1}".+)/, "$2");
-            const title = copy.replace(/(.+title=\\{0,1}")([^"]+)(\\{0,1}".+)/, "$2");
-            return { text: `${step}. ${title}`, level: 2 };
+            const title = copy.replace(/(.+title=\\{0,1}")([^"]+)(\\{0,1}".+)/, "$2")
+                .replace(/(.+title=\\{0,1}')([^']+)(\\{0,1}'.+)/, "$2");
+            return { text: title, level: 2 };
         } 
 
         while (copy[0] === '#') {

--- a/tests/get-headings.test.ts
+++ b/tests/get-headings.test.ts
@@ -17,12 +17,13 @@ test('Correctly parses ### at level 3', () => {
 })
 
 test('Correctly parses <Step> component at level 2', () => {
-  expect(headings.find((heading: any) => heading.text === "1. Title")).toBeTruthy();
+  expect(headings.find((heading: any) => heading.text === "Title")).toBeTruthy();
+  expect(headings.find((heading: any) => heading.text.includes('No Step Number'))).toBeTruthy();
 })
 
 test('Ignores <Step> components if they are missing number or title', () => {
   expect(headings.find((heading: any) => heading.text.includes('25'))).toBeFalsy();
-  expect(headings.find((heading: any) => heading.text.includes('No Step Number'))).toBeFalsy();
+
 })
   
 test('Ignores # lines', () => {

--- a/tests/get-headings.test.ts
+++ b/tests/get-headings.test.ts
@@ -1,0 +1,32 @@
+const { default: getHeadings } = require('../src/scripts/get-headings.ts')
+
+const source = `# Heading 1\n## Heading 2\n\n## Heading 3\nTest text\n\n\nTest text test text\n\n\n`
+  + `<Step number="1" title="Title" />\n<Step title="No Step Number" />\n\n<Step number="25" />\n`;
+let headings: any;
+
+beforeAll(async () => {
+  headings = await getHeadings(source);
+})
+
+test('Correctly parses ## at level 2', () => {
+  expect(headings.find((heading: any) => heading.text === "Heading 2")).toBeTruthy();
+})
+
+test('Correctly parses ### at level 3', () => {
+  expect(headings.find((heading: any) => heading.text === "Heading 3")).toBeTruthy();
+})
+
+test('Correctly parses <Step> component at level 2', () => {
+  expect(headings.find((heading: any) => heading.text === "1. Title")).toBeTruthy();
+})
+
+test('Ignores <Step> components if they are missing number or title', () => {
+  expect(headings.find((heading: any) => heading.text.includes('25'))).toBeFalsy();
+  expect(headings.find((heading: any) => heading.text.includes('No Step Number'))).toBeFalsy();
+})
+  
+test('Ignores # lines', () => {
+  expect(headings.find((heading: any) => heading.text.includes("Heading 1"))).toBeFalsy();
+})
+
+export { }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #59 

Take a look and let me know what you think! The three main judgment calls I made that may or may not be correct:
- Making a more involved regex to accommodate 'number' and 'title' of the component possibly being in a different order
- Ignoring a Step component if it is missing either the number or the title prop. 
- Ignoring single quotes. Every Step component so far has used double quotation marks for strings. However, I do see single quote marks used occasionally throughout the repo. if the style guide/eslint config file changes in the future to enforce single quotes (or if an author uses single quotes for a Step component), that would cause the regex to no longer work.

Also, added a small tweak to WrittenBy.js to prevent the site from crashing if no social links exist (which was happening for me on the page that was used to illustrate the issue.)
