### PR TITLE
Fix (commit-better-code-article)

### DIFF
--- a/content/articles/commit-better-code-with-husky-prettier-eslint-lint-staged.mdx
+++ b/content/articles/commit-better-code-with-husky-prettier-eslint-lint-staged.mdx
@@ -99,12 +99,12 @@ Before we fix these errors, lets make our Prettier config file to help format
 our linted code.
 
 ```Bash
-touch prettierrc.json //or create manually
+touch .prettierrc.json //or create manually
 ```
 
 Once your config file is made, add the following code to sync up both ESLint and Prettier:
 
-```JSON:prettierrc.json
+```JSON:.prettierrc.json
 {
 	"tabWidth": 2,
 	"useTabs": true,


### PR DESCRIPTION
Added missing . for the mentions of the `.prettierrc.json` file. Not including that would cause the prettier file to not be read.